### PR TITLE
Strong params - discussion on using .create instead of (or in addition to) .new

### DIFF
--- a/Rails-M/08rails_strong_parameters.md
+++ b/Rails-M/08rails_strong_parameters.md
@@ -41,10 +41,21 @@ In the controller's `create` method, we can see that this list is referenced whe
 
 ```ruby
 def create
-    @contact = Contact.new(contact_params)
-	...
+    @contact = Contact.create(contact_params)
 end
 ```
+
+Or alternatively
+
+```ruby
+def create
+    @contact = Contact.new(contact_params)
+    ...
+    @contact.save
+end
+```
+
+`.new` will create a new object, while `.create` will create it and save it to the database. If you use `.new`, you need to follow up with `.save` for it to actually be saved. If you have actions you wish to do before putting the object into the database, consider using `.new` instead.
 
 ## Strong params in the form
 


### PR DESCRIPTION
addresses #108 

I added in `.create(params)` as the primary example for the controller create method to reduce confusion, but I kept the `.new` below it, with the addition of mentioning that you have to actually save it when using that.

I also added a bit of discussion about when it would be advantageous to use new instead, but I'm not entirely sure what the rails convention preference is between them