### PR TITLE
fixes broken links in all fetch sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,4 +233,4 @@ The capstone project is the peak experience at LEARN Academy. Students work in a
 
 
 
-## Unit Twelve: Internship Preparation-
+## Unit Twelve: Internship Preparation

--- a/cat-tinder/connecting/fetch-create.md
+++ b/cat-tinder/connecting/fetch-create.md
@@ -53,4 +53,4 @@ As a developer, I have been commissioned to create an application where a user c
 - As a user, I can see my new cat in the cat list.
 
 ---
-[Back to Syllabus] (../../README.md#bringing-it-together)
+[Back to Syllabus](../../README.md#bringing-it-together)

--- a/cat-tinder/connecting/fetch-delete.md
+++ b/cat-tinder/connecting/fetch-delete.md
@@ -70,4 +70,4 @@ As a developer, I have been commissioned to create an application where a user c
 - As a user, I can click the button see all the cats with the specific cat removed.
 
 ---
-[Back to Syllabus] (../../README.md#bringing-it-together)
+[Back to Syllabus](../../README.md#bringing-it-together)

--- a/cat-tinder/connecting/fetch-read.md
+++ b/cat-tinder/connecting/fetch-read.md
@@ -66,4 +66,4 @@ As a developer, I have been commissioned to create an application where a user c
 - As a user, I can see the information for just one cat.
 
 ---
-[Back to Syllabus] (../../README.md#bringing-it-together)
+[Back to Syllabus](../../README.md#bringing-it-together)

--- a/cat-tinder/connecting/fetch-update.md
+++ b/cat-tinder/connecting/fetch-update.md
@@ -53,4 +53,4 @@ As a developer, I have been commissioned to create an application where a user c
 - As a user, I can see the information for my edited cat.
 
 ---
-[Back to Syllabus] (../../README.md#bringing-it-together)
+[Back to Syllabus](../../README.md#bringing-it-together)


### PR DESCRIPTION
Removed the extra space in the link that takes a student back to the syllabus at the bottom of all fetch sections.