### PR TITLE
correcting style guide to reflect the path as bold above code snippet

### DIFF
--- a/github/style-guidelines.md
+++ b/github/style-guidelines.md
@@ -34,7 +34,7 @@ If you would like to contribute to our syllabus, please review the following:
 - All Ruby strings are in single quotes unless necessary for punctuation.
 - Semicolons are not used in JavaScript code unless necessary.
 - Code is formatted into its own distinct block with triple back ticks and styled with the name of the language in all lowercase.
-- File paths appear above code blocks in italics.
+- File paths appear above code blocks in bold.
 
 ### Need Help?
 If you need help, you can ask questions on our LEARN community slack channel or at `contact@learnacademy.org`.


### PR DESCRIPTION
After yesterday conversation, I noticed that the style guide stated to make file paths italic above the code snippet. This PR is changing the instruction to bold to reflect how the syllabus is formatted.